### PR TITLE
Removing image size from image tests as it is variable

### DIFF
--- a/tests/image-test/image.cfg
+++ b/tests/image-test/image.cfg
@@ -75,8 +75,6 @@
         },
         "Architecture": "amd64",
         "Os": "linux",
-        "Size": 334644885,
-        "VirtualSize": 334644885,
         "GraphDriver": {
             "Name": "aufs",
             "Data": null


### PR DESCRIPTION
We should not include the image size in the tests as it is a variable quantity depending on what packages are pulled down in the dockerfile. If the image sizes do not match, the Image test job will fail causing the pipeline to break.
