### PR TITLE
Removing variable docker version and graphDriver data from image tests

### DIFF
--- a/tests/image-test/image.cfg
+++ b/tests/image-test/image.cfg
@@ -37,7 +37,6 @@
             "OnBuild": [],
             "Labels": {}
         },
-        "DockerVersion": "1.11.2",
         "Author": "",
         "Config": {
             "Domainname": "",
@@ -75,10 +74,6 @@
         },
         "Architecture": "amd64",
         "Os": "linux",
-        "GraphDriver": {
-            "Name": "aufs",
-            "Data": null
-        },
         "RootFS": {
             "Type": "layers",
             "Layers": []


### PR DESCRIPTION
Docker version can and GraphDriver seems to varies between different installations of docker engine causing image tests to fail, hence removing it from test config file.
