### PR TITLE
Fix Docker build - wildcard openssl version and set Java version environment variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/local/tomcat
 # runtime dependencies for Tomcat Native Libraries
 # Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
 # see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)
-ENV OPENSSL_VERSION 1.0.2j-1
+ENV OPENSSL_VERSION 1.0.*
 RUN { \
 		echo 'deb http://httpredir.debian.org/debian unstable main'; \
 	} > /etc/apt/sources.list.d/unstable.list \
@@ -25,7 +25,7 @@ RUN { \
 	} > /etc/apt/preferences.d/unstable-openssl
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libapr1 \
-		openssl="$OPENSSL_VERSION" \
+		openssl="${OPENSSL_VERSION}" \
 	&& rm -rf /var/lib/apt/lists/*
 
 # see https://www.apache.org/dist/tomcat/tomcat-8/KEYS
@@ -50,6 +50,7 @@ RUN set -ex \
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.35
 ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
 
 RUN set -x \
 	\


### PR DESCRIPTION
As a user I want to be able to build the Dockerfile.

Issues resolved when building.

`[91mE: Version '1.0.2j-1' for 'openssl' was not found
[0mThe command '/bin/sh -c apt-get update && apt-get install -y --no-install-recommends         libapr1         openssl="$OPENSSL_VERSION"    && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
Build step 'Execute shell' marked build as failure
[ssh-agent] Stopped.`

Solution: wildcard openssl version to future proof.

`[0mThe command '/bin/sh -c set -x       && curl -fSL "$TOMCAT_TGZ_URL" -o tomcat.tar.gz   && curl -fSL "$TOMCAT_TGZ_URL.asc" -o tomcat.tar.gz.asc   && gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz     && tar -xvf tomcat.tar.gz --strip-components=1  && rm bin/*.bat     && rm tomcat.tar.gz*        && nativeBuildDir="$(mktemp -d)"  && tar -xvf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1    && nativeBuildDeps="       gcc         libapr1-dev         libssl-dev      make        openjdk-${JAVA_VERSION%%u*}-jdk=$JAVA_DEBIAN_VERSION    "  && apt-get update && apt-get install -y --no-install-recommends $nativeBuildDeps && rm -rf /var/lib/apt/lists/*     && (        export CATALINA_HOME="$PWD"       && cd "$nativeBuildDir/native"        && ./configure          --libdir=/usr/lib/jni           --prefix="$CATALINA_HOME"             --with-apr=/usr/bin/apr-1-config            --with-java-home="$(docker-java-home)"            --with-ssl=yes      && make -j$(nproc)      && make install     )   && apt-get purge -y --auto-remove $nativeBuildDeps  && rm -rf "$nativeBuildDir"   && rm bin/tomcat-native.tar.gz' returned a non-zero code: 100
Build step 'Execute shell' marked build as failure`

Set Java version environment variable.