### PR TITLE
Use JDK as base image to provide openjdk-8-jdk rather than JRE.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM java:8-jdk
 
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
@@ -50,7 +50,6 @@ RUN set -ex \
 ENV TOMCAT_MAJOR 8
 ENV TOMCAT_VERSION 8.0.35
 ENV TOMCAT_TGZ_URL https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
-ENV JAVA_DEBIAN_VERSION 8u111-b14-2~bpo8+1
 
 RUN set -x \
 	\
@@ -68,7 +67,6 @@ RUN set -x \
 		libapr1-dev \
 		libssl-dev \
 		make \
-		openjdk-${JAVA_VERSION%%u*}-jdk=$JAVA_DEBIAN_VERSION \
 	" \
 	&& apt-get update && apt-get install -y --no-install-recommends $nativeBuildDeps && rm -rf /var/lib/apt/lists/* \
 	&& ( \


### PR DESCRIPTION
We consistently have issues (see below) with a JDK not being installed or repository packages being updated so they are no longer available. 

I have updated the base image to use a JDK rather than a JRE.

`root@0acedf8721c3:/usr/local/tomcat# apt-get install openjdk-8-jdk
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package openjdk-8-jdk
root@0acedf8721c3:/usr/local/tomcat# apt-get update
Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [145 kB]
Get:3 http://httpredir.debian.org unstable InRelease [230 kB]
Get:4 http://deb.debian.org jessie-backports InRelease [166 kB]
Get:5 http://deb.debian.org jessie Release.gpg [2373 B]
Get:6 http://deb.debian.org jessie Release [148 kB]
Get:7 http://security.debian.org jessie/updates/main amd64 Packages [436 kB]
Get:8 http://deb.debian.org jessie-updates/main amd64 Packages [17.6 kB]
Get:9 http://deb.debian.org jessie-backports/main amd64 Packages [1028 kB]
Get:10 http://deb.debian.org jessie/main amd64 Packages [9049 kB]
Get:11 http://httpredir.debian.org unstable/main amd64 Packages [9929 kB]
Fetched 21.2 MB in 14s (1472 kB/s)
Reading package lists... Done
root@0acedf8721c3:/usr/local/tomcat# apt-get install openjdk-8-jdk=8u111-b14-2~bpo8+1
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Version '8u111-b14-2~bpo8+1' for 'openjdk-8-jdk' was not found
root@0acedf8721c3:/usr/local/tomcat# apt-get install openjdk-8-jdk
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 openjdk-8-jdk : Depends: openjdk-8-jre (= 8u121-b13-1~bpo8+1) but it is not going to be installed
                 Depends: openjdk-8-jdk-headless (= 8u121-b13-1~bpo8+1) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.`