### PR TITLE
Remove Git dependency from Dockerfile to pass BDD tests as it is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN set -x \
 		&& make -j$(nproc) \
 		&& make install \
 	) \
-	&& apt-get purge -y --auto-remove $nativeBuildDeps \
+	&& apt-get purge -y --auto-remove $nativeBuildDeps git \
 	&& rm -rf "$nativeBuildDir" \
 	&& rm bin/tomcat-native.tar.gz
 


### PR DESCRIPTION

Remove git dependency as it is not used.

<img width="853" alt="bdd results" src="https://cloud.githubusercontent.com/assets/487240/22561344/be7a0f58-e96f-11e6-929f-49f194ddb96e.png">
