### PR TITLE
Fixing debian jessie issue in apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ ENV PATH $CATALINA_HOME/bin:$PATH
 RUN mkdir -p "$CATALINA_HOME"
 WORKDIR /usr/local/tomcat
 
+RUN echo "deb http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
+RUN echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 # runtime dependencies for Tomcat Native Libraries
 # Tomcat Native 1.2+ requires a newer version of OpenSSL than debian:jessie has available (1.0.2g+)
 # see http://tomcat.10.x6.nabble.com/VOTE-Release-Apache-Tomcat-8-0-32-tp5046007p5046024.html (and following discussion)


### PR DESCRIPTION
java:8-jdk base image is having a debian issue.
It fails to run apt-get update command. Error is 

Step 8/16 : RUN apt-get update && apt-get install -y --no-install-recommends 		libapr1 		openssl="${OPENSSL_VERSION}" 	&& rm -rf /var/lib/apt/lists/*
 ---> Running in ada9f66a8cf6
Get:1 http://ppa.launchpad.net trusty InRelease [15.5 kB]
Ign http://http.debian.net jessie InRelease
Get:2 http://http.debian.net jessie-updates InRelease [7340 B]
Get:3 http://http.debian.net jessie Release.gpg [2420 B]
Get:4 http://security.debian.org jessie/updates InRelease [44.9 kB]
Get:5 http://http.debian.net jessie Release [148 kB]
Get:6 http://security.debian.org jessie/updates/main amd64 Packages [829 kB]
Get:7 http://http.debian.net jessie/main amd64 Packages [9098 kB]
Get:8 http://ppa.launchpad.net trusty/main Sources [20 B]
Get:9 http://ppa.launchpad.net trusty/main amd64 Packages [20 B]
Get:10 http://httpredir.debian.org unstable InRelease [247 kB]
Get:11 http://httpredir.debian.org unstable/main amd64 Packages [11.1 MB]
Fetched 21.5 MB in 16s (1306 kB/s)
[91mW: There is no public key available for the following key IDs:
04EE7237B7D453EC
W: Failed to fetch http://http.debian.net/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file

By adding the changes made by me, this issue will be fixed. This is a global issue with debian images.
Please incorporate the changes in main repository.